### PR TITLE
Use newer version of Rx, use fromEvent operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "./node_modules/.bin/mocha --recursive"
     },
     "dependencies": {
-        "rx": "2.*.*"
+        "rx": "~4.1.0"
     },
     "devDependencies": {
         "mocha": "1.9.0"

--- a/src/index.js
+++ b/src/index.js
@@ -5,32 +5,32 @@ var util = require("util");
 function Server() {
     http.Server.call(this);
 
-    this.requests = Rx.Node
+    this.requests = Rx.Observable
         .fromEvent(this, "request", function(args) {
             return { request: args[0], response: args[1] };
         });
 
-    this.closes = Rx.Node
+    this.closes = Rx.Observable
         .fromEvent(this, "close", function(args) {
             return true;
         });
 
-    this.checkContinues = Rx.Node
+    this.checkContinues = Rx.Observable
         .fromEvent(this, "checkContinue", function(args) {
             return { request: args[0], response: args[1] };
         });
 
-    this.connects = Rx.Node
+    this.connects = Rx.Observable
         .fromEvent(this, "connect", function(args) {
             return { request: args[0], socket: args[1], head: args[2] };
         });
 
-    this.upgrades = Rx.Node
+    this.upgrades = Rx.Observable
         .fromEvent(this, "upgrade", function(args) {
             return { request: args[0], socket: args[1], head: args[2] };
         });
 
-    this.clientErrors = Rx.Node
+    this.clientErrors = Rx.Observable
         .fromEvent(this, "clientError", function(args) {
             return { exception: args[0], socket: args[1] };
         });

--- a/src/index.js
+++ b/src/index.js
@@ -6,33 +6,33 @@ function Server() {
     http.Server.call(this);
 
     this.requests = Rx.Observable
-        .fromEvent(this, "request", function(args) {
-            return { request: args[0], response: args[1] };
+        .fromEvent(this, "request", function() {
+            return { request: arguments[0], response: arguments[1] };
         });
 
     this.closes = Rx.Observable
-        .fromEvent(this, "close", function(args) {
+        .fromEvent(this, "close", function() {
             return true;
         });
 
     this.checkContinues = Rx.Observable
-        .fromEvent(this, "checkContinue", function(args) {
-            return { request: args[0], response: args[1] };
+        .fromEvent(this, "checkContinue", function() {
+            return { request: arguments[0], response: arguments[1] };
         });
 
     this.connects = Rx.Observable
-        .fromEvent(this, "connect", function(args) {
-            return { request: args[0], socket: args[1], head: args[2] };
+        .fromEvent(this, "connect", function() {
+            return { request: arguments[0], socket: arguments[1], head: arguments[2] };
         });
 
     this.upgrades = Rx.Observable
-        .fromEvent(this, "upgrade", function(args) {
-            return { request: args[0], socket: args[1], head: args[2] };
+        .fromEvent(this, "upgrade", function() {
+            return { request: arguments[0], socket: arguments[1], head: arguments[2] };
         });
 
     this.clientErrors = Rx.Observable
-        .fromEvent(this, "clientError", function(args) {
-            return { exception: args[0], socket: args[1] };
+        .fromEvent(this, "clientError", function() {
+            return { exception: arguments[0], socket: arguments[1] };
         });
 }
 


### PR DESCRIPTION
Rx.Node has been moved to its own repo (https://github.com/Reactive-Extensions/rx-node) however, from this comment https://github.com/Reactive-Extensions/rx-node/issues/5#issuecomment-99436697, fromEvent is supported in the main branch. 